### PR TITLE
Add streaming TTS support

### DIFF
--- a/example_streaming.py
+++ b/example_streaming.py
@@ -1,0 +1,33 @@
+import argparse
+import torch
+import torchaudio as ta
+from chatterbox.mtl_tts import ChatterboxMultilingualTTS
+
+def main():
+    parser = argparse.ArgumentParser(description="Stream speech synthesis with Chatterbox.")
+    parser.add_argument("text", help="Text to synthesize.")
+    parser.add_argument("--language_id", "-l", default="en", help="Language code, e.g., 'en', 'fr'.")
+    parser.add_argument("--audio_prompt", "-a", help="Path to an audio prompt for voice cloning.")
+    parser.add_argument("--output", "-o", default="streaming-output.wav", help="Output WAV file path.")
+    args = parser.parse_args()
+
+    if torch.cuda.is_available():
+        device = "cuda"
+    elif torch.backends.mps.is_available():
+        device = "mps"
+    else:
+        device = "cpu"
+    print(f"Using device: {device}")
+
+    model = ChatterboxMultilingualTTS.from_pretrained(device=device)
+
+    chunks = []
+    for chunk in model.generate_stream(args.text, language_id=args.language_id, audio_prompt_path=args.audio_prompt):
+        chunks.append(chunk)
+
+    wav = torch.cat(chunks, dim=1)
+    ta.save(args.output, wav, model.sr)
+
+if __name__ == "__main__":
+    main()
+

--- a/src/chatterbox/models/t3/t3.py
+++ b/src/chatterbox/models/t3/t3.py
@@ -392,3 +392,138 @@ class T3(nn.Module):
         # Concatenate all predicted tokens along the sequence dimension.
         predicted_tokens = torch.cat(predicted, dim=1)  # shape: (B, num_tokens)
         return predicted_tokens
+
+    @torch.inference_mode()
+    def inference_stream(
+        self,
+        *,
+        t3_cond: T3Cond,
+        text_tokens: Tensor,
+        initial_speech_tokens: Optional[Tensor] = None,
+        max_new_tokens: int = 1000,
+        temperature: float = 0.8,
+        cfg_weight: float = 0.5,
+        repetition_penalty: float = 1.2,
+        min_p: float = 0.05,
+        top_p: float = 0.95,
+    ):
+        """Yield speech tokens one-by-one.
+
+        This mirrors :meth:`inference` but instead of returning the full
+        sequence at the end, tokens are yielded as soon as they are sampled.
+        It is intended for streaming TTS where downstream models can consume
+        tokens incrementally.
+
+        Args:
+            t3_cond: Conditionals for T3.
+            text_tokens: Text tokens including BOS/EOS and duplicated for CFG.
+            initial_speech_tokens: Optional starting speech tokens.
+            max_new_tokens: Maximum number of speech tokens to emit.
+            temperature, cfg_weight, repetition_penalty, min_p, top_p: sampling
+                parameters that match those of :meth:`inference`.
+
+        Yields:
+            torch.Tensor: A tensor with shape ``(1, 1)`` containing the newly
+            sampled speech token.
+        """
+
+        _ensure_BOT_EOT(text_tokens, self.hp)
+        text_tokens = torch.atleast_2d(text_tokens).to(dtype=torch.long, device=self.device)
+
+        if initial_speech_tokens is None:
+            initial_speech_tokens = self.hp.start_speech_token * torch.ones_like(text_tokens[:, :1])
+
+        embeds, _ = self.prepare_input_embeds(
+            t3_cond=t3_cond,
+            text_tokens=text_tokens,
+            speech_tokens=initial_speech_tokens,
+            cfg_weight=cfg_weight,
+        )
+
+        self.compiled = False
+        if not self.compiled:
+            alignment_stream_analyzer = None
+            if self.hp.is_multilingual:
+                alignment_stream_analyzer = AlignmentStreamAnalyzer(
+                    self.tfmr,
+                    None,
+                    text_tokens_slice=(embeds.shape[1], embeds.shape[1] + text_tokens.size(-1)),
+                    alignment_layer_idx=9,
+                    eos_idx=self.hp.stop_speech_token,
+                )
+            patched_model = T3HuggingfaceBackend(
+                config=self.cfg,
+                llama=self.tfmr,
+                speech_enc=self.speech_emb,
+                speech_head=self.speech_head,
+                alignment_stream_analyzer=alignment_stream_analyzer,
+            )
+            self.patched_model = patched_model
+            self.compiled = True
+
+        device = embeds.device
+        bos_token = torch.tensor([[self.hp.start_speech_token]], dtype=torch.long, device=device)
+        bos_embed = self.speech_emb(bos_token) + self.speech_pos_emb.get_fixed_embedding(0)
+        bos_embed = torch.cat([bos_embed, bos_embed])
+        inputs_embeds = torch.cat([embeds, bos_embed], dim=1)
+
+        generated_ids = bos_token.clone()
+
+        top_p_warper = TopPLogitsWarper(top_p=top_p)
+        min_p_warper = MinPLogitsWarper(min_p=min_p)
+        repetition_penalty_processor = RepetitionPenaltyLogitsProcessor(penalty=float(repetition_penalty))
+
+        output = self.patched_model(
+            inputs_embeds=inputs_embeds,
+            past_key_values=None,
+            use_cache=True,
+            output_attentions=True,
+            output_hidden_states=True,
+            return_dict=True,
+        )
+        past = output.past_key_values
+
+        for i in range(max_new_tokens):
+            logits_step = output.logits[:, -1, :]
+            cond = logits_step[0:1, :]
+            uncond = logits_step[1:2, :]
+            cfg = torch.as_tensor(cfg_weight, device=cond.device, dtype=cond.dtype)
+            logits = cond + cfg * (cond - uncond)
+
+            if self.patched_model.alignment_stream_analyzer is not None:
+                if logits.dim() == 1:
+                    logits = logits.unsqueeze(0)
+                last_token = generated_ids[0, -1].item() if generated_ids.size(1) > 0 else None
+                logits = self.patched_model.alignment_stream_analyzer.step(logits, next_token=last_token)
+
+            ids_for_proc = generated_ids[:1, ...]
+            logits = repetition_penalty_processor(ids_for_proc, logits)
+
+            if temperature != 1.0:
+                logits = logits / temperature
+
+            logits = min_p_warper(ids_for_proc, logits)
+            logits = top_p_warper(ids_for_proc, logits)
+
+            probs = torch.softmax(logits, dim=-1)
+            next_token = torch.multinomial(probs, num_samples=1)
+
+            generated_ids = torch.cat([generated_ids, next_token], dim=1)
+
+            yield next_token
+
+            if next_token.view(-1) == self.hp.stop_speech_token:
+                break
+
+            next_token_embed = self.speech_emb(next_token)
+            next_token_embed = next_token_embed + self.speech_pos_emb.get_fixed_embedding(i + 1)
+            next_token_embed = torch.cat([next_token_embed, next_token_embed])
+            output = self.patched_model(
+                inputs_embeds=next_token_embed,
+                past_key_values=past,
+                output_attentions=True,
+                output_hidden_states=True,
+                return_dict=True,
+            )
+            past = output.past_key_values
+

--- a/src/chatterbox/tts.py
+++ b/src/chatterbox/tts.py
@@ -270,3 +270,81 @@ class ChatterboxTTS:
             wav = wav.squeeze(0).detach().cpu().numpy()
             watermarked_wav = self.watermarker.apply_watermark(wav, sample_rate=self.sr)
         return torch.from_numpy(watermarked_wav).unsqueeze(0)
+
+    def generate_stream(
+        self,
+        text,
+        repetition_penalty=1.2,
+        min_p=0.05,
+        top_p=1.0,
+        audio_prompt_path=None,
+        exaggeration=0.5,
+        cfg_weight=0.5,
+        temperature=0.8,
+    ):
+        """Yield audio chunks while generating speech."""
+        if audio_prompt_path:
+            self.prepare_conditionals(audio_prompt_path, exaggeration=exaggeration)
+        else:
+            assert self.conds is not None, "Please `prepare_conditionals` first or specify `audio_prompt_path`"
+
+        if exaggeration != self.conds.t3.emotion_adv[0, 0, 0]:
+            _cond: T3Cond = self.conds.t3
+            self.conds.t3 = T3Cond(
+                speaker_emb=_cond.speaker_emb,
+                cond_prompt_speech_tokens=_cond.cond_prompt_speech_tokens,
+                emotion_adv=exaggeration * torch.ones(1, 1, 1),
+            ).to(device=self.device)
+
+        text = punc_norm(text)
+        text_tokens = self.tokenizer.text_to_tokens(text).to(self.device)
+
+        if cfg_weight > 0.0:
+            text_tokens = torch.cat([text_tokens, text_tokens], dim=0)
+
+        sot = self.t3.hp.start_text_token
+        eot = self.t3.hp.stop_text_token
+        text_tokens = F.pad(text_tokens, (1, 0), value=sot)
+        text_tokens = F.pad(text_tokens, (0, 1), value=eot)
+
+        stream = self.t3.inference_stream(
+            t3_cond=self.conds.t3,
+            text_tokens=text_tokens,
+            max_new_tokens=1000,
+            temperature=temperature,
+            cfg_weight=cfg_weight,
+            repetition_penalty=repetition_penalty,
+            min_p=min_p,
+            top_p=top_p,
+        )
+
+        speech_tokens = []
+        cache_source = None
+        prev_len = 0
+        for tok in stream:
+            speech_tokens.append(tok.item())
+            st = torch.tensor(speech_tokens, dtype=torch.long, device=self.device).unsqueeze(0)
+            wav, cache_source = self.s3gen.inference(
+                speech_tokens=st,
+                ref_dict=self.conds.gen,
+                cache_source=cache_source,
+                finalize=False,
+            )
+            wav = wav.squeeze(0).detach().cpu().numpy()
+            chunk = wav[prev_len:]
+            prev_len = wav.shape[0]
+            if len(chunk) > 0:
+                chunk = self.watermarker.apply_watermark(chunk, sample_rate=self.sr)
+                yield torch.from_numpy(chunk).unsqueeze(0)
+
+        st = torch.tensor(speech_tokens, dtype=torch.long, device=self.device).unsqueeze(0)
+        wav, _ = self.s3gen.inference(
+            speech_tokens=st,
+            ref_dict=self.conds.gen,
+            finalize=True,
+        )
+        wav = wav.squeeze(0).detach().cpu().numpy()
+        chunk = wav[prev_len:]
+        if len(chunk) > 0:
+            chunk = self.watermarker.apply_watermark(chunk, sample_rate=self.sr)
+            yield torch.from_numpy(chunk).unsqueeze(0)


### PR DESCRIPTION
## Summary
- add `inference_stream` to T3 for incremental token generation
- support streaming audio output in English and multilingual TTS classes
- include example demonstrating streaming synthesis with CLI arguments for text, language and optional audio prompt

## Testing
- `python -m py_compile src/chatterbox/models/t3/t3.py src/chatterbox/mtl_tts.py src/chatterbox/tts.py example_streaming.py`


------
https://chatgpt.com/codex/tasks/task_e_68c71420579c832e89521456fa9b3e4a